### PR TITLE
Protects against null path equal signs

### DIFF
--- a/lib/twig/branch.rb
+++ b/lib/twig/branch.rb
@@ -12,7 +12,8 @@ class Twig
 
         properties = config_lines.map do |line|
           # Split by rightmost `=`, allowing branch names to contain `=`:
-          key, value = line.match(/(.+)=(.+)/)[1..2]
+          key, value = line.match(/(.+)=(.+)/){|m| m[1..2]}
+          next if key.nil?
 
           key_parts = key.split('.')
           key_parts.last if key_parts[0] == 'branch' && key_parts.size > 2

--- a/spec/twig/branch_spec.rb
+++ b/spec/twig/branch_spec.rb
@@ -49,6 +49,13 @@ describe Twig::Branch do
       result.should == %w[eqproperty test0 test1 test2]
     end
 
+    it 'skips path values with an equal sign but no value' do
+      @config << 'foo_path='
+      Twig.should_receive(:run).with('git config --list').and_return(@config)
+      result = Twig::Branch.all_properties
+      result.should_not include 'foo_path'
+    end
+
     it 'memoizes the result' do
       Twig.should_receive(:run).once.and_return(@config)
       2.times { Twig::Branch.all_properties }


### PR DESCRIPTION
If you have a bad setting with no value in your .gitconfig, such as 

```
 foo = bar
 path = 
```

`self.all_properties` would try to access the nil value as an array, which would throw a `NoMethodError` exception.
