### PR TITLE
Fixed failing test: using %w() instead of %[]

### DIFF
--- a/spec/twig_spec.rb
+++ b/spec/twig_spec.rb
@@ -158,7 +158,7 @@ describe Twig do
     end
 
     it 'returns a message if all branches were filtered out by options' do
-      @twig.stub(:all_branches => %[foo bar])
+      @twig.stub(:all_branches => %w(foo bar))
       @twig.stub(:branches => [])
 
       @twig.list_branches.should include(


### PR DESCRIPTION
Using %w() instead of %[] because the latter returned a string instead of an array.
