### PR TITLE
Fixed columns first (date, branch name) and the properties after with more space

### DIFF
--- a/lib/twig/display.rb
+++ b/lib/twig/display.rb
@@ -53,19 +53,19 @@ class Twig
 
       out =
         column(' ', columns_for_date_time) <<
+        column(branch_indicator_padding + 'branch',
+          5, header_options) <<
         Twig::Branch.all_properties.map do |property|
           column(property, columns_per_property, header_options)
         end.join <<
-        column(branch_indicator_padding + 'branch',
-          columns_per_property, header_options) <<
         "\n"
       out <<
         column(' ', columns_for_date_time) <<
+        column(branch_indicator_padding + '------',
+          5, header_options) <<
         Twig::Branch.all_properties.map do |property|
           column('-' * property.size, columns_per_property, header_options)
         end.join <<
-        column(branch_indicator_padding + '------',
-          columns_per_property, header_options) <<
         "\n"
 
       out
@@ -83,18 +83,18 @@ class Twig
 
       line = column(branch.last_commit_time.to_s, 5)
 
-      line <<
-        Twig::Branch.all_properties.map do |property_name|
-          property = properties[property_name] || ''
-          column(property, 2)
-        end.join
-
-      line <<
-        if is_current_branch
-          CURRENT_BRANCH_INDICATOR + branch.to_s
+      br = if is_current_branch
+          CURRENT_BRANCH_INDICATOR + branch.to_s + "  "
         else
           (' ' * CURRENT_BRANCH_INDICATOR.size) + branch.to_s
         end
+      line << column(br, 5)
+
+      line <<
+        Twig::Branch.all_properties.map do |property_name|
+          property = properties[property_name] || ''
+          column(property, 20)
+        end.join
 
       line = format_string(line, :weight => :bold) if is_current_branch
 


### PR DESCRIPTION
The idea is to have a reordering of columns based on priorities.

Here I can't see the branch description:

![Screen Shot 2013-02-14 at 11 07 28 AM](https://f.cloud.github.com/assets/16540/156268/7b771e88-768e-11e2-86f8-470b9d58cadf.png)

Here I can: 

![Screen Shot 2013-02-14 at 11 07 41 AM](https://f.cloud.github.com/assets/16540/156266/78627b70-768e-11e2-90b3-2428d2600fe6.png)
