### PR TITLE
Fix URL for twig homepage

### DIFF
--- a/lib/twig/cli.rb
+++ b/lib/twig/cli.rb
@@ -19,7 +19,7 @@ class Twig
 
         #{intro}
 
-        https://rondevera.github.com/twig
+        http://rondevera.github.com/twig
 
       BANNER
     end


### PR DESCRIPTION
`twig --help` directs users to https://rondevera.github.com/twig, which I could not get to resolve. I suspect that *.github.com are not https because http://rondevera.github.com/twig works for me:

```
$ twig git:(fix_homepage_url) ✗ curl -I https://rondevera.github.com/twig/
curl: (7) couldn't connect to host
$ twig git:(fix_homepage_url) ✗ curl -I http://rondevera.github.com/twig/ 
HTTP/1.1 200 OK
Server: GitHub.com
Date: Wed, 13 Mar 2013 06:15:08 GMT
Content-Type: text/html
Content-Length: 16508
Last-Modified: Thu, 07 Mar 2013 06:16:48 GMT
Connection: keep-alive
Expires: Wed, 13 Mar 2013 06:25:08 GMT
Cache-Control: max-age=600
Accept-Ranges: bytes
```
